### PR TITLE
Add draggable ticker ordering and sitewide ticker bar

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -5,6 +5,7 @@
     <title>Account - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
 </head>
 <body>
 <div id="sidebar">
@@ -29,6 +30,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>Account</h2>
     <p id="welcome"></p>
     <form id="account-form">

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,6 +5,7 @@
     <title>Admin - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
 </head>
 <body>
 <div id="sidebar">
@@ -29,6 +30,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>User Management</h2>
     <table id="users"><thead><tr><th>Username</th><th>Email</th><th>OTP</th><th>Admin</th><th>Last Login</th><th>New Password</th><th>Actions</th></tr></thead><tbody></tbody></table>
 </main>

--- a/frontend/backtests.html
+++ b/frontend/backtests.html
@@ -5,6 +5,7 @@
     <title>Backtests - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
 </head>
 <body>
 <div id="sidebar">
@@ -30,6 +31,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>Run Backtest</h2>
     <label>Symbol <input id="bt-symbol"></label>
     <label>Start <input type="date" id="bt-start" value="2023-01-01"></label>

--- a/frontend/help.html
+++ b/frontend/help.html
@@ -5,6 +5,7 @@
     <title>Help - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
     <style>main h2{margin-top:40px;}</style>
 </head>
 <body>
@@ -29,6 +30,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2 id="index">Dashboard</h2>
     <p>The main dashboard shows a scrolling ticker, quick price tiles and news feeds. Use the <em>Pause</em> button to stop the ticker. Tiles show the first four symbols from your saved list.</p>
 

--- a/frontend/journal.html
+++ b/frontend/journal.html
@@ -5,6 +5,7 @@
     <title>Journal - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
 </head>
 <body>
 <div id="sidebar">
@@ -29,6 +30,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>Trade Journal</h2>
     <table id="journal-table">
         <thead>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -5,6 +5,7 @@
     <title>Login - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
@@ -30,6 +31,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>Login</h2>
     <form id="login-form">
         <label>Username<input type="text" id="username"></label>

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -5,6 +5,7 @@
     <title>Signals - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="ticker.js"></script>
 </head>
 <body>
 <div id="sidebar">
@@ -29,6 +30,7 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>Signals</h2>
 
     <section class="signal-section">

--- a/frontend/theme.js
+++ b/frontend/theme.js
@@ -19,6 +19,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   initAuth();
   initHeader();
+  if (window.initTickerBar) {
+    initTickerBar();
+  }
 });
 
 function initAuth() {

--- a/frontend/ticker.js
+++ b/frontend/ticker.js
@@ -1,0 +1,63 @@
+// Simple ticker bar loader used on all pages
+let tickerSymbols = ['AAPL','MSFT','GOOGL','AMZN','TSLA','SPY','QQQ','GLD','BTC-USD','ETH-USD'];
+let tickerPaused = false;
+
+async function loadUserTickers(){
+  const userId = localStorage.getItem('userId');
+  if(!userId) return;
+  try {
+    const resp = await fetch(`/api/users/${userId}/tickers`);
+    if(resp.ok){
+      const data = await resp.json();
+      if(data.tickers && data.tickers.length){
+        tickerSymbols = data.tickers;
+      }
+    }
+  } catch(e) {}
+}
+
+async function updateTickerBar(){
+  await loadUserTickers();
+  const track = document.getElementById('ticker-track');
+  if(!track) return;
+  const res = await fetch('/api/ticker?symbols=' + tickerSymbols.join(','));
+  const data = await res.json();
+  track.innerHTML = '';
+  data.data.forEach(item => {
+    const span = document.createElement('span');
+    const cls = item.change_percent >= 0 ? 'up' : 'down';
+    span.className = 'ticker-item ' + cls;
+    if(item.price === null){
+      span.textContent = `${item.symbol} N/A`;
+    } else {
+      const priceStr = item.price < 1 ? item.price.toFixed(5) : item.price.toFixed(2);
+      span.textContent = `${item.symbol} ${priceStr} (${item.change_percent.toFixed(2)}%)`;
+    }
+    track.appendChild(span);
+  });
+  track.innerHTML += track.innerHTML;
+}
+
+function toggleTicker(){
+  const track = document.getElementById('ticker-track');
+  if(!track) return;
+  tickerPaused = !tickerPaused;
+  track.style.animationPlayState = tickerPaused ? 'paused' : 'running';
+  document.getElementById('ticker-toggle').textContent = tickerPaused ? 'Play' : 'Pause';
+}
+
+function initTickerBar(){
+  if(document.getElementById('ticker-bar')) return; // already added
+  const main = document.querySelector('main');
+  if(!main) return;
+  const bar = document.createElement('div');
+  bar.id = 'ticker-bar';
+  bar.innerHTML = '<button id="ticker-toggle">Pause</button><div id="ticker-track"></div>';
+  main.prepend(bar);
+  document.getElementById('ticker-toggle').addEventListener('click', toggleTicker);
+  updateTickerBar();
+  setInterval(updateTickerBar, 60000);
+}
+
+// expose for manual use if needed
+window.initTickerBar = initTickerBar;

--- a/frontend/tickers.html
+++ b/frontend/tickers.html
@@ -5,6 +5,8 @@
     <title>Tickers - MacMarket</title>
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+    <script src="ticker.js"></script>
 </head>
 <body>
 <div id="sidebar">
@@ -29,11 +31,13 @@
     <div id="status"></div>
 </header>
 <main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
     <h2>Manage Tickers</h2>
     <table id="ticker-table"><tbody id="tickers-body"></tbody></table>
     <input id="new-ticker" placeholder="Add ticker">
     <button id="add-ticker">Add</button>
     <div>
+        <button id="sort-tickers">Sort A-Z</button>
         <button id="save-tickers">Save</button>
     </div>
 </main>
@@ -53,6 +57,7 @@
         body.innerHTML='';
         function addRow(sym, checked){
             const tr=document.createElement('tr');
+            tr.draggable=true;
             const cb=document.createElement('input');
             cb.type='checkbox';
             cb.value=sym;
@@ -66,25 +71,37 @@
         }
         defaults.forEach(sym=> addRow(sym, current.includes(sym)) );
         current.filter(s=>!defaults.includes(s)).forEach(sym=> addRow(sym, true));
+        new Sortable(body, {animation:150});
     }
     document.getElementById('add-ticker').addEventListener('click', ()=>{
         const val=document.getElementById('new-ticker').value.trim();
         if(val){
             const body=document.getElementById('tickers-body');
             const tr=document.createElement('tr');
+            tr.draggable=true;
             const cb=document.createElement('input');
             cb.type='checkbox'; cb.value=val; cb.checked=true;
             tr.innerHTML=`<td></td><td>${val}</td>`;
             tr.firstChild.appendChild(cb);
             body.appendChild(tr);
-            document.getElementById('new-ticker').value='';
         }
+        document.getElementById('new-ticker').value='';
     });
     document.getElementById('save-tickers').addEventListener('click', async ()=>{
         const checked = Array.from(document.querySelectorAll('#tickers-body input[type=checkbox]')).filter(c=>c.checked).map(c=>c.value);
         setStatus('Saving...', 'loading');
         await fetch(`/api/users/${userId}/tickers`, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify({tickers: checked})});
         setStatus('Saved!', 'ok');
+    });
+    document.getElementById('sort-tickers').addEventListener('click', ()=>{
+        const body=document.getElementById('tickers-body');
+        const rows=Array.from(body.querySelectorAll('tr'));
+        rows.sort((a,b)=>{
+            const sa=a.children[1].textContent.toUpperCase();
+            const sb=b.children[1].textContent.toUpperCase();
+            return sa.localeCompare(sb);
+        });
+        rows.forEach(r=>body.appendChild(r));
     });
     if(localStorage.getItem('isAdmin') === '1'){
         document.getElementById('admin-link').style.display='block';


### PR DESCRIPTION
## Summary
- create `ticker.js` with reusable ticker-bar logic
- load ticker-bar on every page via `theme.js`
- show the ticker bar across account, admin, backtests, help, journal, login, signals and tickers pages
- allow drag-and-drop ticker ordering and alphabetical sort on `tickers.html`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871254697f8832695cbb9b1269fd059