### PR TITLE
Fix static file serving and add backtests links

### DIFF
--- a/app.py
+++ b/app.py
@@ -602,6 +602,35 @@ def theme_js():
         return Response(js_file.read_text(), media_type="application/javascript")
     raise HTTPException(status_code=404, detail="Not Found")
 
+# Additional static assets for the simple frontend
+@app.get("/ticker.js")
+def ticker_js():
+    js_file = FRONTEND_DIR / "ticker.js"
+    if js_file.exists():
+        return Response(js_file.read_text(), media_type="application/javascript")
+    raise HTTPException(status_code=404, detail="Not Found")
+
+@app.get("/Dashboard.jsx")
+def dashboard_jsx():
+    jsx_file = FRONTEND_DIR / "Dashboard.jsx"
+    if jsx_file.exists():
+        return Response(jsx_file.read_text(), media_type="application/javascript")
+    raise HTTPException(status_code=404, detail="Not Found")
+
+@app.get("/TopCongressBuysWidget.jsx")
+def congress_widget_jsx():
+    jsx_file = FRONTEND_DIR / "TopCongressBuysWidget.jsx"
+    if jsx_file.exists():
+        return Response(jsx_file.read_text(), media_type="application/javascript")
+    raise HTTPException(status_code=404, detail="Not Found")
+
+@app.get("/TopCongressBuysWidget.css")
+def congress_widget_css():
+    css_file = FRONTEND_DIR / "TopCongressBuysWidget.css"
+    if css_file.exists():
+        return Response(css_file.read_text(), media_type="text/css")
+    raise HTTPException(status_code=404, detail="Not Found")
+
 
 # Serve simple static HTML pages for the frontend
 @app.get("/{page_name}", response_class=HTMLResponse)

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -15,6 +15,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="help.html#account">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -15,6 +15,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="admin.html">Admin</a>
     <a href="help.html#admin">Help</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/help.html
+++ b/frontend/help.html
@@ -16,6 +16,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="help.html#index">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/journal.html
+++ b/frontend/journal.html
@@ -15,6 +15,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="help.html#journal">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,6 +16,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="help.html#login">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -15,6 +15,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="help.html#signals">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/tickers.html
+++ b/frontend/tickers.html
@@ -16,6 +16,7 @@
     <a href="tickers.html">Tickers</a>
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
     <a href="help.html#tickers">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>


### PR DESCRIPTION
## Summary
- serve frontend React and widget scripts through FastAPI
- link to backtests page from all sidebars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687148aa9a248326b2f0c197318af757