### PR TITLE
Serve React build and dashboard data

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import backend.app.security as security
 from backend.app import risk
 import pyotp
 from backend.app import signals, backtest, alerts
-from backend.app.signals import format_price
+from backend.app.signals import format_price, fetch_unusual_whales
 from datetime import datetime
 import json
 from fastapi import Request
@@ -555,9 +555,10 @@ def list_backtests(user_id: int | None = None, db: Session = Depends(get_db)):
     return runs
 
 @app.get("/api/signals/alert")
-def latest_alert():
-    """Return the latest trading alert."""
-    return LATEST_ALERT
+async def latest_alert():
+    """Return recent whale alerts."""
+    alerts = await fetch_unusual_whales()
+    return alerts
 
 
 @app.post("/api/signals/alert")

--- a/backend/app/signals.py
+++ b/backend/app/signals.py
@@ -72,6 +72,28 @@ def get_whale_moves(limit: int = 5) -> list[dict]:
     return []
 
 
+async def fetch_unusual_whales(limit: int = 5) -> list[dict]:
+    """Fetch latest unusual whale alerts."""
+    import httpx
+
+    key = os.getenv("WHALES_API_KEY")
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.get(
+                "https://api.unusualwhales.com/alerts", headers=headers
+            )
+            if r.status_code == 200:
+                data = r.json()
+                if isinstance(data, dict):
+                    data = data.get("results", data)
+                if isinstance(data, list):
+                    return data[:limit]
+    except Exception:
+        pass
+    return []
+
+
 def get_political_moves(symbols: list[str]) -> dict:
     """Return counts of recent congressional trades for each symbol."""
     key = os.getenv("QUIVER_API_KEY")

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import 'dotenv/config';
 import { fetchMarket } from './services/marketData.js';
 import { fetchPolitical } from './services/politicalData.js';
@@ -10,6 +12,8 @@ import { runBacktest } from './backtest/strategyEngine.js';
 import { fetchDiscord } from './services/discordData.js';
 import { validateMessages } from './services/validateDiscussion.js';
 import { query as dbQuery } from './db/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -72,7 +76,10 @@ app.post('/api/scenarios', express.json(), async (req, res) => {
   }
 });
 
-app.use(express.static('frontend'));
+app.use(express.static(path.join(__dirname, 'frontend', 'build')));
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve(__dirname, 'frontend', 'build', 'index.html'));
+});
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,13 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import BacktestPage from './components/BacktestPage.jsx';
-
-function Home() {
-  return <div>Home</div>;
-}
+import Dashboard from './components/Dashboard.jsx';
 
 export default function App() {
   return (
     <BrowserRouter>
-      <nav>
-        <NavLink to="/">Home</NavLink> |{' '}
-        <NavLink to="/backtest">Backtest</NavLink>
-      </nav>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Dashboard />} />
         <Route path="/backtest" element={<BacktestPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+
+export default function Dashboard() {
+  const [alerts, setAlerts] = useState([]);
+  const [political, setPolitical] = useState([]);
+  const [riskScores, setRiskScores] = useState([]);
+  const [whaleMoves, setWhaleMoves] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/signals/alert')
+      .then(res => res.json()).then(setAlerts).catch(() => setAlerts([]));
+
+    fetch('/api/quiver/political')
+      .then(res => res.json()).then(d => setPolitical(d.political || d)).catch(() => setPolitical([]));
+
+    fetch('/api/quiver/risk?symbols=AAPL,MSFT,GOOGL,AMZN,TSLA,SPY,QQQ,GLD,BTC-USD,ETH-USD,RVN-USD,XMR-USD')
+      .then(res => res.json()).then(d => setRiskScores(d.risk || d)).catch(() => setRiskScores([]));
+
+    fetch('/api/quiver/whales?limit=5')
+      .then(res => res.json()).then(d => setWhaleMoves(d.whales || d)).catch(() => setWhaleMoves([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Unusual Whales</h2>
+      {alerts.length ? alerts.map(a => <div key={a.id || a.transaction_id}>{a.summary || JSON.stringify(a)}</div>)
+                     : <p>No whale alerts currently.</p>}
+
+      <h2>Capitol Trades</h2>
+      {political.map(tx => (
+        <div key={tx.Date + tx.Ticker}>{`${tx.Date} – ${tx.Ticker} ${tx.Transaction}`}</div>
+      ))}
+
+      <h2>Quiver Risk Scores</h2>
+      {riskScores.length ? riskScores.map(r => <div key={r.ticker}>{`${r.ticker}: ${r.score}`}</div>)
+                         : <p>No risk scores available.</p>}
+
+      <h2>Quiver Whale Moves</h2>
+      {whaleMoves.length ? whaleMoves.map(w => <div key={w.transaction_id}>{`${w.symbol}: ${w.amount}`}</div>)
+                         : <p>No whale moves right now.</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- serve React build for non-API routes
- add async unusual whale alerts fetch
- update `/api/signals/alert` to return whale alerts
- create Dashboard component fetching multiple APIs
- wire Dashboard through React router

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871a6940e188326b9769b8e092f4952