### PR TITLE
Implement exit date/price logic

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,7 +75,10 @@ def test_recommendations_endpoint(monkeypatch):
             {
                 "symbol": "AAPL",
                 "action": "buy",
-                "exit": {"low": 100, "medium": 105, "high": 110},
+                "entry_date": "2024-01-01",
+                "entry_price": 100,
+                "exit_date": "2024-01-10",
+                "exit_price": 105,
                 "probability": 0.6,
                 "reason": "test",
             }
@@ -102,7 +105,10 @@ def test_single_recommendation(monkeypatch):
             {
                 "symbol": symbols[0],
                 "action": "buy",
-                "exit": {"low": 9, "medium": 10, "high": 11},
+                "entry_date": "2024-01-01",
+                "entry_price": 10,
+                "exit_date": "2024-01-02",
+                "exit_price": 11,
                 "probability": 0.5,
                 "reason": "r",
             }
@@ -151,8 +157,26 @@ def test_signal_rankings_json(monkeypatch):
     monkeypatch.setattr(
         "app.signals.generate_recommendations",
         lambda syms: [
-            {"symbol": "A", "probability": 0.8, "action": "buy", "exit": {"low": 9, "medium": 10, "high": 12}, "reason": "r"},
-            {"symbol": "B", "probability": 0.5, "action": "buy", "exit": {"low": 9, "medium": 10, "high": 12}, "reason": "r"},
+            {
+                "symbol": "A",
+                "probability": 0.8,
+                "action": "buy",
+                "entry_date": "2024-01-01",
+                "entry_price": 1,
+                "exit_date": "2024-01-10",
+                "exit_price": 1.1,
+                "reason": "r",
+            },
+            {
+                "symbol": "B",
+                "probability": 0.5,
+                "action": "buy",
+                "entry_date": "2024-01-01",
+                "entry_price": 1,
+                "exit_date": "2024-01-10",
+                "exit_price": 1.1,
+                "reason": "r",
+            },
         ],
     )
     resp = client.get("/api/signals/rankings")
@@ -166,8 +190,26 @@ def test_signal_rankings_csv(monkeypatch):
     monkeypatch.setattr(
         "app.signals.generate_recommendations",
         lambda syms: [
-            {"symbol": "A", "probability": 0.7, "action": "buy", "exit": {"low": 0, "medium": 0, "high": 0}, "reason": "r"},
-            {"symbol": "B", "probability": 0.4, "action": "sell", "exit": {"low": 0, "medium": 0, "high": 0}, "reason": "r"},
+            {
+                "symbol": "A",
+                "probability": 0.7,
+                "action": "buy",
+                "entry_date": "2024-01-01",
+                "entry_price": 1,
+                "exit_date": "2024-01-10",
+                "exit_price": 1.1,
+                "reason": "r",
+            },
+            {
+                "symbol": "B",
+                "probability": 0.4,
+                "action": "sell",
+                "entry_date": "2024-01-01",
+                "entry_price": 1,
+                "exit_date": "2024-01-10",
+                "exit_price": 1.1,
+                "reason": "r",
+            },
         ],
     )
     resp = client.get("/api/signals/rankings?format=csv")

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -8,11 +8,8 @@ def test_generate_recommendations_quiver(monkeypatch):
     monkeypatch.setattr(signals, "_current_price", lambda s: 100.0)
     monkeypatch.setattr(
         signals,
-        "_exit_levels",
-        lambda sym, act, price: (
-            {"low": price + 1, "medium": price + 2, "high": price + 3},
-            "x",
-        ),
+        "_calculate_exit",
+        lambda sym, price, date: (date, price + 5),
     )
     monkeypatch.setattr(signals, "get_political_moves", lambda syms: {"AAPL": 1})
     monkeypatch.setattr(signals, "get_lobby_disclosures", lambda syms: {"AAPL": 2})


### PR DESCRIPTION
## Summary
- add configurable exit strategy constants
- compute exit date/price in `_calculate_exit`
- return entry and exit data from `generate_recommendations`
- update unit tests for new API shape

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ab5f91a48326ab73464f80007ebe