### PR TITLE
Add GitHub page with README

### DIFF
--- a/app.py
+++ b/app.py
@@ -756,12 +756,20 @@ def congress_widget_css():
         return Response(css_file.read_text(), media_type="text/css")
     raise HTTPException(status_code=404, detail="Not Found")
 
+# Serve the project README for display on the GitHub page
+@app.get("/readme")
+def get_readme():
+    readme_file = Path(__file__).resolve().parent / "README.md"
+    if readme_file.exists():
+        return Response(readme_file.read_text(), media_type="text/plain")
+    raise HTTPException(status_code=404, detail="Not Found")
+
 
 # Serve simple static HTML pages for the frontend
 @app.get("/{page_name}", response_class=HTMLResponse)
 def serve_page(page_name: str):
     """Return one of the bundled frontend HTML pages."""
-    allowed_pages = {"index.html", "login.html", "account.html", "tickers.html", "signals.html", "journal.html", "backtests.html", "admin.html", "help.html"}
+    allowed_pages = {"index.html", "login.html", "account.html", "tickers.html", "signals.html", "journal.html", "backtests.html", "admin.html", "help.html", "github.html"}
     if page_name in allowed_pages:
         html_file = FRONTEND_DIR / page_name
         if html_file.exists():

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -16,6 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#account">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -16,6 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="admin.html">Admin</a>
     <a href="help.html#admin">Help</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/backtests.html
+++ b/frontend/backtests.html
@@ -16,6 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#backtests">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/github.html
+++ b/frontend/github.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>GitHub & Documentation - MacMarket</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="theme.js"></script>
+    <script src="ticker.js"></script>
+</head>
+<body>
+<div id="sidebar">
+    <a href="index.html">Home</a>
+    <a href="login.html">Login</a>
+    <a href="account.html">Account</a>
+    <a href="tickers.html">Tickers</a>
+    <a href="signals.html">Signals</a>
+    <a href="journal.html">Journal</a>
+    <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
+    <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
+    <a href="#" id="logout-link">Logout</a>
+    <select id="theme-select">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+    </select>
+</div>
+<header>
+    <h1>MacMarket</h1>
+    <div id="user-info"></div>
+    <div id="time"></div>
+    <div id="status"></div>
+</header>
+<main>
+    <div id="ticker-bar"><button id="ticker-toggle">Pause</button><div id="ticker-track"></div></div>
+    <h2>Project Repository</h2>
+    <p>View the code on <a id="gh-link" href="https://github.com/ryanm-plastic-recycling/MacMarket" target="_blank" rel="noopener">GitHub</a>.</p>
+    <h2>README</h2>
+    <pre id="readme"></pre>
+</main>
+<script>
+fetch('/readme')
+  .then(r => r.text())
+  .then(text => { document.getElementById('readme').textContent = text; });
+</script>
+</body>
+</html>

--- a/frontend/help.html
+++ b/frontend/help.html
@@ -17,6 +17,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#index">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/journal.html
+++ b/frontend/journal.html
@@ -16,6 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#journal">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -17,6 +17,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#login">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -16,6 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#signals">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>

--- a/frontend/tickers.html
+++ b/frontend/tickers.html
@@ -17,6 +17,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
+    <a href="github.html">GitHub</a>
     <a href="help.html#tickers">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>


### PR DESCRIPTION
## Summary
- serve README via `/readme` endpoint
- allow new `github.html` page
- link to GitHub page from every sidebar
- add actual `github.html` to show repo URL and README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b4a2c1648326a0b316d957818b21