### PR TITLE
Improve API responsiveness with caching and async requests

### DIFF
--- a/tests/test_panorama.py
+++ b/tests/test_panorama.py
@@ -20,7 +20,11 @@ def test_panorama(monkeypatch):
     monkeypatch.setattr('app.political', dummy_political)
     monkeypatch.setattr('app.quiver_risk', dummy_quiver_risk)
     monkeypatch.setattr('app.quiver_whales', dummy_quiver_whales)
-    monkeypatch.setattr('app.news', lambda age='week': {"market": [], "world": []})
+
+    async def dummy_news(age='week'):
+        return {"market": [], "world": []}
+
+    monkeypatch.setattr('app.news', dummy_news)
 
     resp = client.get('/api/panorama')
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add optional TTL caches for news and political API data
- fetch news and political feeds with `httpx.AsyncClient`
- gather dashboard data concurrently in `/api/panorama`
- update panorama test for async news function

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743ffcebf4832699c1252c4f4d88dd