### PR TITLE
Add fetch-readme script

### DIFF
--- a/fetch-readme.js
+++ b/fetch-readme.js
@@ -1,0 +1,21 @@
+import { marked } from 'marked';
+import { writeFile } from 'fs/promises';
+
+const README_URL = 'https://raw.githubusercontent.com/ryanmccauley/MacMarket/main/README.md';
+
+async function fetchAndConvert() {
+  try {
+    const response = await fetch(README_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch README: ${response.status} ${response.statusText}`);
+    }
+    const markdown = await response.text();
+    const html = marked.parse(markdown);
+    await writeFile('latest-readme.html', html);
+    console.log('README pulled and converted to HTML.');
+  } catch (err) {
+    console.error('Error fetching or converting README:', err);
+  }
+}
+
+fetchAndConvert();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "discord.js": "^14.13.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "marked": "^16.0.0",
         "mysql2": "^3.9.7",
         "node-fetch": "^3.3.2",
         "openai": "^4.104.0",
@@ -1125,6 +1126,18 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
       "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.0.0.tgz",
+      "integrity": "sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "discord.js": "^14.13.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "marked": "^16.0.0",
     "mysql2": "^3.9.7",
     "node-fetch": "^3.3.2",
     "openai": "^4.104.0",


### PR DESCRIPTION
## Summary
- add `fetch-readme.js` to download README and convert to HTML using `marked`
- install `marked` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `node fetch-readme.js` *(fails: `fetch failed` due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6874420caea88326a767b38401cb7d02