### PR TITLE
Embed contextual help

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -16,8 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#account">Help</a>
+    <a href="github.html">GitHub</a>account">Help</a>#account">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -87,5 +86,7 @@
 
     loadProfile();
 </script>
+<script src="help.js"></script>
+<script>initHelp("account");</script>
 </body>
 </html>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -17,8 +17,7 @@
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
     <a href="github.html">GitHub</a>
-    <a href="admin.html">Admin</a>
-    <a href="help.html#admin">Help</a>
+    <a href="admin.html">Admin</a>admin">Help</a>#admin">Help</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
         <option value="light">Light</option>
@@ -184,5 +183,7 @@
         return escapeHtml(String(data));
     }
 </script>
+<script src="help.js"></script>
+<script>initHelp("admin");</script>
 </body>
 </html>

--- a/frontend/backtests.html
+++ b/frontend/backtests.html
@@ -16,8 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#backtests">Help</a>
+    <a href="github.html">GitHub</a>backtests">Help</a>#backtests">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -96,5 +95,7 @@ window.onload = () => {
     document.getElementById('bt-run').addEventListener('click', runBacktest);
 };
 </script>
+<script src="help.js"></script>
+<script>initHelp("backtests");</script>
 </body>
 </html>

--- a/frontend/github.html
+++ b/frontend/github.html
@@ -42,5 +42,7 @@ fetch('/readme')
   .then(r => r.text())
   .then(text => { document.getElementById('readme').textContent = text; });
 </script>
+<script src="help.js"></script>
+<script>initHelp("github");</script>
 </body>
 </html>

--- a/frontend/help.js
+++ b/frontend/help.js
@@ -1,0 +1,78 @@
+const helpContent = {
+  index: `
+    <h2>Dashboard</h2>
+    <p>The dashboard shows market data. The scrolling ticker displays prices for your saved symbols. Click <strong>Pause</strong> to stop the scroll.</p>
+    <p>Tiles underneath show the latest price and percent change for the first four tickers plus BTC and ETH.</p>
+    <h3>Alerts</h3>
+    <p>The alerts list shows the latest signals from data sources. Example output:<br><code>ALERT: SPY bullish breakout</code></p>
+    <h3>Political Trading Activity</h3>
+    <p>Shows recent congressional trades from QuiverQuant.</p>
+    <h3>News</h3>
+    <p>Select a range (7 days, 30 days or All) to filter the market and world news feeds.</p>
+  `,
+  login: `
+    <h2>Login</h2>
+    <p>Enter your account credentials and optionally a one time password.</p>
+    <pre>Username: demo\nPassword: yourpass\nOTP: 123456</pre>
+    <p>On success you are redirected to your account page.</p>
+  `,
+  account: `
+    <h2>Account</h2>
+    <p>Change your username, email or password. Check <em>Enable OTP</em> to require a one time password when logging in.</p>
+    <p>Example: update email then click <strong>Save</strong> to submit.</p>
+  `,
+  tickers: `
+    <h2>Manage Tickers</h2>
+    <p>Use the table to select the symbols you want across the site. Add tickers with the input box, drag to reorder and click <strong>Save</strong>.</p>
+    <p>Example input: <code>NVDA</code> then press <strong>Add</strong>.</p>
+  `,
+  signals: `
+    <h2>Signals</h2>
+    <p><strong>Symbol Signal</strong> fetches news sentiment and a moving-average based technical signal.</p>
+    <p>Example input: <code>AAPL</code> then click <strong>Get Signal</strong>. The response shows sentiment score and technical trend.</p>
+    <p><strong>Macro Outlook</strong> analyzes pasted text with an LLM.</p>
+    <p><strong>Recommendations</strong> loads suggestions for your saved tickers.</p>
+    <p><strong>Get Recommendation for Symbol</strong> queries a specific ticker.</p>
+  `,
+  journal: `
+    <h2>Journal</h2>
+    <p>Review past trades and current positions. Fill out the form to add a new entry.</p>
+    <p>Example: symbol <code>AAPL</code>, action <code>buy</code>, quantity <code>10</code>, price <code>150</code>, then click <strong>Add</strong>. The new entry appears in the table.</p>
+  `,
+  backtests: `
+    <h2>Backtests</h2>
+    <p>Run a simple historical test of a trading strategy.</p>
+    <p>Example: symbol <code>SPY</code>, start <code>2023-01-01</code>, end <code>2024-01-01</code>, then click <strong>Run</strong>. The results appear in JSON and are saved in the table.</p>
+  `,
+  admin: `
+    <h2>Admin Panel</h2>
+    <p>Manage users and test API integrations. Edit user details in the table and click <strong>Save</strong>.</p>
+    <p>The API tester lets you send a request to each configured endpoint and view the response.</p>
+  `,
+  github: `
+    <h2>GitHub</h2>
+    <p>This page shows a link to the project repository and the README contents loaded from the server.</p>
+  `
+};
+
+function initHelp(page){
+  const header = document.querySelector('header');
+  if(!header) return;
+  const btn = document.createElement('button');
+  btn.id = 'help-btn';
+  btn.className = 'help-button';
+  btn.textContent = '?';
+  header.appendChild(btn);
+
+  const overlay = document.createElement('div');
+  overlay.id = 'help-overlay';
+  overlay.innerHTML = '<div class="help-content"><button id="help-close">Close</button><div id="help-body"></div></div>';
+  document.body.appendChild(overlay);
+  btn.addEventListener('click', () => {
+    document.getElementById('help-body').innerHTML = helpContent[page] || '';
+    overlay.style.display = 'block';
+  });
+  document.getElementById('help-close').addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,8 +20,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#index">Help</a>
+    <a href="github.html">GitHub</a>index">Help</a>#index">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -311,5 +310,7 @@ async function init() {
 <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
 <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 <script type="text/babel" src="Dashboard.jsx"></script>
+<script src="help.js"></script>
+<script>initHelp("index");</script>
 </body>
 </html>

--- a/frontend/journal.html
+++ b/frontend/journal.html
@@ -16,8 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#journal">Help</a>
+    <a href="github.html">GitHub</a>journal">Help</a>#journal">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -181,5 +180,7 @@ window.onload = () => {
     loadPositions();
 };
 </script>
+<script src="help.js"></script>
+<script>initHelp("journal");</script>
 </body>
 </html>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -17,8 +17,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#login">Help</a>
+    <a href="github.html">GitHub</a>login">Help</a>#login">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -79,5 +78,7 @@
         }
     });
 </script>
+<script src="help.js"></script>
+<script>initHelp("login");</script>
 </body>
 </html>

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -16,8 +16,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#signals">Help</a>
+    <a href="github.html">GitHub</a>signals">Help</a>#signals">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -170,5 +169,7 @@ document.getElementById('run-macro').addEventListener('click', fetchMacro);
 document.getElementById('get-recs').addEventListener('click', fetchRecs);
 document.getElementById('get-single').addEventListener('click', fetchSingle);
 </script>
+<script src="help.js"></script>
+<script>initHelp("signals");</script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -266,3 +266,44 @@ th { border-bottom: 1px solid #ccc; }
   background: var(--ticker-bg);
   color: var(--ticker-text);
 }
+
+.help-button {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  border: none;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+#help-overlay {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.6);
+  display: none;
+  z-index: 2000;
+}
+
+.help-content {
+  background: var(--bg-color);
+  color: var(--text-color);
+  max-width: 800px;
+  max-height: 80%;
+  overflow: auto;
+  margin: 5% auto;
+  padding: 20px;
+  border-radius: 8px;
+  position: relative;
+}
+
+#help-close {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}

--- a/frontend/tickers.html
+++ b/frontend/tickers.html
@@ -17,8 +17,7 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>
-    <a href="help.html#tickers">Help</a>
+    <a href="github.html">GitHub</a>tickers">Help</a>#tickers">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
@@ -111,5 +110,7 @@
     }
     window.onload=loadTickers;
 </script>
+<script src="help.js"></script>
+<script>initHelp("tickers");</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace sidebar Help link with in-page help overlay
- add help.js and help styles
- initialize help overlay on each page with content specific to that page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874427af38c8326b8152e138c2c8a51