### PR TITLE
Fix help links in navigation

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -16,7 +16,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>account">Help</a>#account">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#account">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -17,7 +17,8 @@
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
     <a href="github.html">GitHub</a>
-    <a href="admin.html">Admin</a>admin">Help</a>#admin">Help</a>
+    <a href="admin.html">Admin</a>
+    <a href="help.html#admin">Help</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">
         <option value="light">Light</option>

--- a/frontend/backtests.html
+++ b/frontend/backtests.html
@@ -16,7 +16,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>backtests">Help</a>#backtests">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#backtests">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>index">Help</a>#index">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#index">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/journal.html
+++ b/frontend/journal.html
@@ -16,7 +16,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>journal">Help</a>#journal">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#journal">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -17,7 +17,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>login">Help</a>#login">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#login">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -16,7 +16,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>signals">Help</a>#signals">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#signals">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">

--- a/frontend/tickers.html
+++ b/frontend/tickers.html
@@ -17,7 +17,8 @@
     <a href="signals.html">Signals</a>
     <a href="journal.html">Journal</a>
     <a href="backtests.html">Backtests</a>
-    <a href="github.html">GitHub</a>tickers">Help</a>#tickers">Help</a>
+    <a href="github.html">GitHub</a>
+    <a href="help.html#tickers">Help</a>
     <a href="admin.html" id="admin-link" style="display:none;">Admin</a>
     <a href="#" id="logout-link">Logout</a>
     <select id="theme-select">


### PR DESCRIPTION
## Summary
- repair broken `Help` links across HTML pages so that the sidebar shows separate `GitHub` and `Help` links

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687447cb54b083269fd92b915c1419a3