### PR TITLE
Add Congress long-short strategy tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,13 @@ Several additional endpoints are available:
 * `GET /api/quiver/risk?symbols=AAPL,MSFT` &mdash; returns Quiver risk scores for the specified tickers (requires `QUIVER_API_KEY`).
 * `GET /api/quiver/whales?limit=5` &mdash; lists recent whale moves limited to the given number (requires `QUIVER_API_KEY`).
 * `GET /api/quiver/political?symbols=AAPL` &mdash; counts of recent congressional trades for the tickers (requires `QUIVER_API_KEY`).
+* `POST /strategy-test/congress-long-short` &mdash; run the Congress Long-Short strategy backtest.
 * `GET /api/quiver/lobby?symbols=AAPL` &mdash; counts of recent lobbying disclosures for the tickers (requires `QUIVER_API_KEY`).
+Example:
+```bash
+curl -X POST http://localhost:9500/strategy-test/congress-long-short
+```
+
 
 The frontend now includes `signals.html`, `journal.html`, and `backtests.html` pages to interact with these endpoints and view saved results.
 

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 import yfinance as yf
 import requests
+from macmarket.strategy_tester import CongressLongShortTester
 import pandas as pd
 import asyncio
 import httpx
@@ -679,6 +680,14 @@ def list_backtests(user_id: int | None = None, db: Session = Depends(get_db)):
     for r in runs:
         r.metrics = json.loads(r.metrics)
     return runs
+
+@app.post("/strategy-test/congress-long-short")
+async def run_congress_backtest():
+    """Trigger the backtest and return summary performance metrics."""
+    tester = CongressLongShortTester()
+    metrics = tester.run_backtest()
+    return metrics
+
 
 @app.get("/api/signals/alert")
 async def latest_alert():

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+quiver_api_token: "YOUR_QUIVER_TOKEN"
+strategy_tester:
+  initial_capital: 100000
+  lookback_days: 7
+  rebalance_frequency_days: 7

--- a/macmarket/paper_trader.py
+++ b/macmarket/paper_trader.py
@@ -1,0 +1,49 @@
+import pandas as pd
+
+class PaperTrader:
+    """Very simple paper trading engine for backtesting."""
+    def __init__(self, initial_capital: float = 100000.0):
+        self.initial_capital = initial_capital
+        self.cash = initial_capital
+        self.positions: dict[str, float] = {}
+        self.history: list[dict] = []
+
+    def _record(self, date, **fields):
+        rec = {"date": pd.to_datetime(date).date(), **fields}
+        self.history.append(rec)
+
+    def target_weights(self, weights: dict[str, float], prices: dict[str, float], date) -> None:
+        """Adjust holdings to match the target weights at given prices."""
+        equity = self.portfolio_value(prices)
+        for sym, target_w in weights.items():
+            price = prices.get(sym)
+            if price is None or price <= 0:
+                continue
+            target_dollar = equity * target_w
+            target_qty = target_dollar / price
+            current_qty = self.positions.get(sym, 0.0)
+            delta = target_qty - current_qty
+            if abs(delta) < 1e-8:
+                continue
+            action = "buy" if delta > 0 else "sell"
+            self.cash -= delta * price
+            self.positions[sym] = current_qty + delta
+            self._record(date, symbol=sym, action=action, quantity=abs(delta), price=float(price))
+        self._record(date, equity=self.portfolio_value(prices))
+
+    def portfolio_value(self, prices: dict[str, float]) -> float:
+        value = self.cash
+        for sym, qty in self.positions.items():
+            price = prices.get(sym)
+            if price is not None:
+                value += qty * price
+        return float(value)
+
+    def finalize(self, prices: dict[str, float], date) -> float:
+        """Record final equity value."""
+        equity = self.portfolio_value(prices)
+        self._record(date, equity=equity)
+        return equity
+
+    def history_df(self) -> pd.DataFrame:
+        return pd.DataFrame(self.history)

--- a/macmarket/strategy_tester.py
+++ b/macmarket/strategy_tester.py
@@ -1,0 +1,141 @@
+import os
+import pandas as pd
+import datetime
+import requests
+import yfinance as yf
+from pathlib import Path
+from .paper_trader import PaperTrader
+from backend.app.backtest import _performance_metrics
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
+
+
+def _load_config() -> dict:
+    if CONFIG_PATH.is_file():
+        try:
+            import yaml
+            with open(CONFIG_PATH) as f:
+                data = yaml.safe_load(f) or {}
+            return data
+        except Exception:
+            return {}
+    return {}
+
+
+class CongressLongShortTester:
+    """Backtester for the Congress Long-Short strategy."""
+
+    def __init__(self) -> None:
+        cfg = _load_config()
+        strat_cfg = cfg.get("strategy_tester", {})
+        self.api_token = cfg.get("quiver_api_token") or os.getenv("QUIVER_API_KEY")
+        self.initial_capital = strat_cfg.get("initial_capital", 100000.0)
+        self.lookback_days = strat_cfg.get("lookback_days", 7)
+        self.rebalance_freq = strat_cfg.get("rebalance_frequency_days", 7)
+        self.output_csv = Path("data/backtests/congress_long_short.csv")
+        self.output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    def _fetch_trades(self, start: datetime.date, end: datetime.date) -> pd.DataFrame:
+        headers = {"Authorization": f"Bearer {self.api_token}"} if self.api_token else {}
+        url = "https://api.quiverquant.com/beta/live/congresstrading"
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, dict):
+            data = data.get("data", data)
+        df = pd.DataFrame(data)
+        if df.empty:
+            return pd.DataFrame(columns=["date", "symbol", "size", "signal"])
+        sym_col = next((c for c in ["Ticker", "ticker", "Symbol", "symbol"] if c in df.columns), None)
+        date_col = next((c for c in ["Date", "TransactionDate", "TradeDate", "date"] if c in df.columns), None)
+        action_col = next((c for c in ["Transaction", "Action", "Type"] if c in df.columns), None)
+        size_col = next((c for c in ["Range", "Size", "amount", "Amount"] if c in df.columns), None)
+        df = df.rename(columns={sym_col: "symbol", date_col: "date", action_col: "action", size_col: "size"})
+        df["date"] = pd.to_datetime(df["date"]).dt.date
+        df["signal"] = df["action"].str.contains("buy", case=False).astype(int)
+        df.loc[df["action"].str.contains("sell|sale", case=False), "signal"] = -1
+        df["size"] = df["size"].apply(self._parse_size)
+        df = df[(df["date"] >= start) & (df["date"] <= end)]
+        return df[["date", "symbol", "size", "signal"]]
+
+    @staticmethod
+    def _parse_size(val) -> float:
+        if isinstance(val, (int, float)):
+            return float(val)
+        if isinstance(val, str):
+            parts = val.replace("$", "").replace(",", "").split("-")
+            nums = []
+            for p in parts:
+                try:
+                    nums.append(float(p))
+                except ValueError:
+                    continue
+            if nums:
+                return sum(nums) / len(nums)
+        return 1.0
+
+    def _weights_from_trades(self, trades: pd.DataFrame) -> dict[str, float]:
+        if trades.empty:
+            return {}
+        longs = trades[trades["signal"] == 1].groupby("symbol")["size"].sum()
+        shorts = trades[trades["signal"] == -1].groupby("symbol")["size"].sum()
+        total = longs.sum() + shorts.sum()
+        weights: dict[str, float] = {}
+        if total == 0:
+            return weights
+        for sym, val in longs.items():
+            weights[sym] = weights.get(sym, 0.0) + val / total
+        for sym, val in shorts.items():
+            weights[sym] = weights.get(sym, 0.0) - val / total
+        return weights
+
+    def _price_series(self, symbols: list[str], start: datetime.date, end: datetime.date) -> dict[str, pd.Series]:
+        data = {}
+        for sym in symbols:
+            try:
+                df = yf.download(sym, start=start, end=end + datetime.timedelta(days=1), progress=False)
+                if not df.empty:
+                    data[sym] = df["Close"].ffill()
+            except Exception:
+                pass
+        return data
+
+    @staticmethod
+    def _nearest(series: pd.Series, date: datetime.date) -> float | None:
+        if series.empty:
+            return None
+        dt = pd.to_datetime(date)
+        if dt in series.index:
+            return float(series.loc[dt])
+        before = series.loc[:dt]
+        if not before.empty:
+            return float(before.iloc[-1])
+        return float(series.iloc[0])
+
+    def run_backtest(self) -> dict:
+        today = datetime.date.today()
+        start_date = today - datetime.timedelta(days=self.rebalance_freq + self.lookback_days)
+        trades = self._fetch_trades(start_date - datetime.timedelta(days=self.lookback_days), today)
+        symbols = sorted(trades["symbol"].unique())
+        prices = self._price_series(symbols, start_date, today)
+        rebalance_date = start_date
+        pt = PaperTrader(self.initial_capital)
+        equity_curve = []
+        while rebalance_date < today:
+            lb_start = rebalance_date - datetime.timedelta(days=self.lookback_days)
+            subset = trades[(trades["date"] > lb_start) & (trades["date"] <= rebalance_date)]
+            weights = self._weights_from_trades(subset)
+            price_map = {s: self._nearest(prices.get(s, pd.Series(dtype=float)), rebalance_date) for s in weights}
+            pt.target_weights(weights, price_map, rebalance_date)
+            equity = pt.portfolio_value({s: self._nearest(prices.get(s, pd.Series(dtype=float)), rebalance_date) for s in pt.positions})
+            equity_curve.append({"date": rebalance_date, "equity": equity})
+            rebalance_date += datetime.timedelta(days=self.rebalance_freq)
+        final_prices = {s: self._nearest(prices.get(s, pd.Series(dtype=float)), today) for s in pt.positions}
+        final_equity = pt.finalize(final_prices, today)
+        equity_curve.append({"date": today, "equity": final_equity})
+        hist_df = pt.history_df()
+        hist_df.to_csv(self.output_csv, index=False)
+        eq_df = pd.DataFrame(equity_curve).set_index("date")
+        eq_df["strategy_return"] = eq_df["equity"].pct_change().fillna(0)
+        metrics = _performance_metrics(eq_df)
+        return metrics


### PR DESCRIPTION
## Summary
- introduce `macmarket` package with a simple `PaperTrader` and new `CongressLongShortTester`
- wire tester into FastAPI via `/strategy-test/congress-long-short`
- add configuration defaults in `config.yaml`
- document new endpoint in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687693af40e083268e67822079fe64ef