### PR TITLE
Fix missing setStatus on backtests page

### DIFF
--- a/frontend/backtests.html
+++ b/frontend/backtests.html
@@ -6,6 +6,26 @@
     <link rel="stylesheet" href="style.css">
     <script src="theme.js"></script>
     <script src="ticker.js"></script>
+<script>
+if(typeof window.setStatus!=="function"){
+  window.setStatus=function(message,type=""){
+    const div=document.getElementById("status");
+    if(!div) return;
+    if(message){
+      div.textContent=message;
+      div.className=type;
+      div.style.display="block";
+    } else {
+      div.textContent="";
+      div.className="";
+      div.style.display="none";
+    }
+  };
+}
+if(typeof setStatus!=="function"){
+  function setStatus(message,type=""){ window.setStatus(message,type); }
+}
+</script>
 </head>
 <body>
 <div id="sidebar">


### PR DESCRIPTION
## Summary
- ensure `setStatus` exists on `backtests.html`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b75bd6c88326aca838c634c7fae8