### PR TITLE
Fix page load Unicode error

### DIFF
--- a/app.py
+++ b/app.py
@@ -855,7 +855,8 @@ def serve_page(page_name: str):
     if page_name in allowed_pages:
         html_file = FRONTEND_DIR / page_name
         if html_file.exists():
-            return html_file.read_text()
+            # Explicitly read using UTF-8 to avoid locale dependent decoding
+            return html_file.read_text(encoding="utf-8")
     raise HTTPException(status_code=404, detail="Not Found")
 
 


### PR DESCRIPTION
## Summary
- read HTML files using UTF-8 encoding when serving pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876e160ba348326833705a268297131