### PR TITLE
Fix SMA backtest error and enforce uppercase tickers

### DIFF
--- a/backend/app/backtest.py
+++ b/backend/app/backtest.py
@@ -29,7 +29,8 @@ def _performance_metrics(df: pd.DataFrame) -> dict:
 
 def sma_crossover_backtest(symbol: str, start: str = "2023-01-01", end: str | None = None) -> dict:
     """Run a simple SMA crossover backtest and return trades and metrics."""
-    df = yf.download(symbol, start=start, end=end)
+    symbol = symbol.upper()
+    df = yf.download(symbol, start=start, end=end, progress=False)
     if df.empty:
         return {"trades": [], "metrics": {}, "equity": []}
 
@@ -44,12 +45,13 @@ def sma_crossover_backtest(symbol: str, start: str = "2023-01-01", end: str | No
     df["equity"] = (1 + df["strategy_return"]).cumprod()
 
     trades = []
-    prev = 0
+    prev = 0.0
     for date, row in df.iterrows():
-        if row["signal"] != prev and row["signal"] != 0:
-            action = "buy" if row["signal"] == 1 else "sell"
+        signal = float(row["signal"])
+        if signal != prev and signal != 0:
+            action = "buy" if signal == 1 else "sell"
             trades.append({"date": date.strftime("%Y-%m-%d"), "action": action, "price": float(row["Close"])})
-        prev = row["signal"]
+        prev = signal
 
     metrics = _performance_metrics(df)
     equity = [

--- a/frontend/backtests.html
+++ b/frontend/backtests.html
@@ -92,7 +92,7 @@ async function loadBacktests(){
 }
 
 async function runBacktest(){
-    const symbol = document.getElementById('bt-symbol').value.trim();
+    const symbol = document.getElementById('bt-symbol').value.trim().toUpperCase();
     const start = document.getElementById('bt-start').value;
     const end = document.getElementById('bt-end').value;
     if(!symbol) return;
@@ -154,7 +154,12 @@ window.onload = () => {
     loadStrategies();
     document.getElementById('bt-run').addEventListener('click', runBacktest);
     document.getElementById('st-run').addEventListener('click', runStrategy);
-    document.getElementById('bt-start').value = new Date().toISOString().split('T')[0];
+    const btSym = document.getElementById('bt-symbol');
+    btSym.addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
+    const today = new Date();
+    document.getElementById('bt-end').value = today.toISOString().split('T')[0];
+    const past = new Date(today); past.setDate(past.getDate()-30);
+    document.getElementById('bt-start').value = past.toISOString().split('T')[0];
 };
 </script>
 <script src="help.js"></script>

--- a/frontend/journal.html
+++ b/frontend/journal.html
@@ -160,7 +160,7 @@ async function loadPositions(){
 document.getElementById('journal-form').addEventListener('submit', async e => {
     e.preventDefault();
     const payload = {
-        symbol: document.getElementById('symbol').value.trim(),
+        symbol: document.getElementById('symbol').value.trim().toUpperCase(),
         action: document.getElementById('action').value,
         quantity: parseFloat(document.getElementById('quantity').value),
         price: parseFloat(document.getElementById('price').value),
@@ -177,6 +177,7 @@ window.onload = () => {
     loadJournal();
     loadPositions();
 };
+document.getElementById('symbol').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
 </script>
 <script src="help.js"></script>
 <script>initHelp("journal");</script>

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -86,7 +86,7 @@
 if(localStorage.getItem('isAdmin') === '1'){ document.getElementById('admin-link').style.display='block'; }
 
 async function fetchSignal(){
-    const sym = document.getElementById('symbol').value.trim();
+    const sym = document.getElementById('symbol').value.trim().toUpperCase();
     if(!sym) return;
     setStatus('Loading signal...', 'loading');
     const res = await fetch(`/api/signals/${sym}`);
@@ -145,7 +145,7 @@ async function fetchRecs(){
 }
 
 async function fetchSingle(){
-    const sym = document.getElementById('single-symbol').value.trim();
+    const sym = document.getElementById('single-symbol').value.trim().toUpperCase();
     if(!sym) return;
     setStatus('Loading...', 'loading');
     const res = await fetch(`/api/recommendation/${sym}`);
@@ -166,6 +166,8 @@ document.getElementById('get-signal').addEventListener('click', fetchSignal);
 document.getElementById('run-macro').addEventListener('click', fetchMacro);
 document.getElementById('get-recs').addEventListener('click', fetchRecs);
 document.getElementById('get-single').addEventListener('click', fetchSingle);
+document.getElementById('symbol').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
+document.getElementById('single-symbol').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
 </script>
 <script src="help.js"></script>
 <script>initHelp("signals");</script>

--- a/frontend/tickers.html
+++ b/frontend/tickers.html
@@ -74,7 +74,7 @@
         new Sortable(body, {animation:150});
     }
     document.getElementById('add-ticker').addEventListener('click', ()=>{
-        const val=document.getElementById('new-ticker').value.trim();
+        const val=document.getElementById('new-ticker').value.trim().toUpperCase();
         if(val){
             const body=document.getElementById('tickers-body');
             const tr=document.createElement('tr');
@@ -107,6 +107,7 @@
         document.getElementById('admin-link').style.display='block';
     }
     window.onload=loadTickers;
+    document.getElementById('new-ticker').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
 </script>
 <script src="help.js"></script>
 <script>initHelp("tickers");</script>


### PR DESCRIPTION
## Summary
- fix ambiguous boolean comparison in `sma_crossover_backtest`
- normalize tickers to uppercase before downloading data
- update backtests page with default start/end dates and uppercase enforcement
- enforce uppercase ticker input on signals, journal and tickers pages

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876eb96b84083269aa0df63f4f5a080