### PR TITLE
Expand HACO arrow markers and add signal-only chart

### DIFF
--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -95,6 +95,7 @@
             <button id="haco-run">Run</button>
         </div>
         <div id="haco-chart" style="height:400px;"></div>
+        <div id="haco-signal-chart" style="height:100px;"></div>
         <div id="haco-explain"></div>
         <div id="haco-scan">
             <input id="haco-scanList" placeholder="Symbols comma separated">

--- a/static/js/haco-ui.js
+++ b/static/js/haco-ui.js
@@ -20,6 +20,12 @@ function renderChart(series){
     const chartEl = document.getElementById('haco-chart');
     chartEl.innerHTML = '';
     const chart = LightweightCharts.createChart(chartEl, {height:400});
+
+    const signalChartEl = document.getElementById('haco-signal-chart');
+    if(signalChartEl){
+        signalChartEl.innerHTML = '';
+    }
+    const signalChart = LightweightCharts.createChart(signalChartEl, {height:100});
     const candleSeries = chart.addCandlestickSeries();
     const haToggle = document.getElementById('haco-toggleHa').checked;
 
@@ -33,8 +39,8 @@ function renderChart(series){
             res.color = '#e74c3c';
             res.borderColor = '#e74c3c';
         }
-        if(bar.upw) markers.push({time: bar.time, position:'belowBar', color:'green', shape:'arrowUp'});
-        if(bar.dnw) markers.push({time: bar.time, position:'aboveBar', color:'red', shape:'arrowDown'});
+        if(bar.upw) markers.push({time: bar.time, position:'belowBar', color:'green', shape:'arrowUp', size:3});
+        if(bar.dnw) markers.push({time: bar.time, position:'aboveBar', color:'red', shape:'arrowDown', size:3});
         return res;
     });
     candleSeries.setData(candles);
@@ -54,6 +60,10 @@ function renderChart(series){
         const haSeries = chart.addCandlestickSeries({upColor:'#999', downColor:'#555'});
         haSeries.setData(series.map(b=>({time:b.time, open:b.haOpen, high:Math.max(b.h,b.haOpen), low:Math.min(b.l,b.haOpen), close:b.haC})));
     }
+
+    const signalSeries = signalChart.addHistogramSeries({base:0, priceFormat:{type:'volume'}, lineWidth:5});
+    const signalData = series.map(b=>({time:b.time, value:1, color:b.state?'#2ecc71':'#e74c3c'}));
+    signalSeries.setData(signalData);
 }
 
 function explainLast(last){


### PR DESCRIPTION
## Summary
- Enlarge HACO strategy chart arrows to three times their previous size
- Add dedicated HACO signal chart displaying red/green states below main chart

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e352cf6e48326979b0ef2f0c6c860