### PR TITLE
Add visible HACO overlay arrows and pin chart version

### DIFF
--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -7,6 +7,12 @@
     <link rel="stylesheet" href="style.css">
 <script type="module" src="theme.js"></script>
     <script src="ticker.js"></script>
+    <style>
+        .haco-overlay { position:absolute; left:0; top:0; width:100%; height:100%; pointer-events:none; }
+        .haco-arrow { position:absolute; transform:translate(-50%,-50%); line-height:1; text-shadow:0 0 3px rgba(0,0,0,.45); font-weight:700; }
+        .haco-arrow.up   { color:#16a34a; }
+        .haco-arrow.down { color:#dc2626; }
+    </style>
 </head>
 <body>
 <div id="sidebar">
@@ -94,7 +100,7 @@
             <label><input type="checkbox" id="haco-toggleHa"> Show Heikin-Ashi</label>
             <button id="haco-run">Run</button>
         </div>
-        <div id="haco-chart" style="height:400px;"></div>
+        <div id="haco-chart" style="height:400px; position:relative;"></div>
         <div id="haco-signal-chart" style="height:100px;"></div>
         <div id="haco-explain"></div>
         <div id="haco-scan">
@@ -200,7 +206,16 @@ document.getElementById('get-single').addEventListener('click', fetchSingle);
 document.getElementById('symbol').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
 document.getElementById('single-symbol').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
 </script>
-<script src="https://unpkg.com/lightweight-charts@4.0.0/dist/lightweight-charts.standalone.production.js"></script>
+<script src="https://unpkg.com/lightweight-charts@5.0.0/dist/lightweight-charts.standalone.production.js"></script>
+<script>
+    (function(){
+      const scripts = Array.from(document.scripts);
+      const lw = scripts.find(s => s.src.includes('lightweight-charts'));
+      console.log('[HACO] Loaded Lightweight Charts:', lw?.src || '(inline)');
+      // Some builds expose version; if not, the pinned URL is our source of truth
+      console.log('[HACO] LW Charts version (from URL):', (lw?.src.match(/@([\d.]+)/)||[])[1] || 'unknown');
+    })();
+  </script>
 <script src="/static/js/haco-ui.js?v=1"></script>
 <script src="help.js"></script>
 <script>initHelp("signals");</script>

--- a/static/js/haco-ui.js
+++ b/static/js/haco-ui.js
@@ -20,6 +20,38 @@ function renderChart(series){
     const chartEl = document.getElementById('haco-chart');
     chartEl.innerHTML = '';
     const chart = LightweightCharts.createChart(chartEl, {height:400, width: chartEl.clientWidth});
+    const overlay = document.createElement('div');
+    overlay.className = 'haco-overlay';
+    chartEl.appendChild(overlay);
+
+    function drawOverlayArrows(series, chart, candleSeries, overlayEl, px = 26) {
+        overlayEl.innerHTML = '';
+        const ts = chart.timeScale();
+        for (const b of series) {
+            if (!b.upw && !b.dnw) continue;
+
+            const x = ts.timeToCoordinate(b.time);
+            const yAnchor = b.upw ? b.low ?? b.l : b.high ?? b.h;
+            const y = candleSeries.priceToCoordinate(yAnchor);
+            if (x == null || y == null) continue;
+
+            const el = document.createElement('div');
+            el.className = `haco-arrow ${b.upw ? 'up' : 'down'}`;
+            el.textContent = b.upw ? '▲' : '▼';
+            el.style.left = `${x}px`;
+            el.style.top  = `${y + (b.upw ? 14 : -14)}px`;
+            el.style.fontSize = `${px}px`;
+            overlayEl.appendChild(el);
+        }
+    }
+
+    function rafRedraw(fn) {
+        let rafId = null;
+        return function(...args){
+            if (rafId) cancelAnimationFrame(rafId);
+            rafId = requestAnimationFrame(() => fn(...args));
+        };
+    }
 
     const signalChartEl = document.getElementById('haco-signal-chart');
     if(signalChartEl){
@@ -52,19 +84,26 @@ function renderChart(series){
     candleSeries.setData(candles);
     candleSeries.setMarkers(markers);
 
+    const redraw = rafRedraw(() => drawOverlayArrows(series, chart, candleSeries, overlay, 28));
+    redraw();
+
+    chart.timeScale().subscribeVisibleTimeRangeChange(redraw);
+    chart.subscribeCrosshairMove(redraw);
+    window.addEventListener('resize', redraw);
+
     const zlHaU = chart.addLineSeries({color:'blue'});
     const zlClU = chart.addLineSeries({color:'orange'});
     const zlHaD = chart.addLineSeries({color:'purple'});
     const zlClD = chart.addLineSeries({color:'gray'});
 
-    zlHaU.setData(series.map(b=>({time:b.time, value:b.ZlHaU})));
-    zlClU.setData(series.map(b=>({time:b.time, value:b.ZlClU})));
-    zlHaD.setData(series.map(b=>({time:b.time, value:b.ZlHaD})));
-    zlClD.setData(series.map(b=>({time:b.time, value:b.ZlClD})));
+    zlHaU.setData(series.map(b=>({time:b.time, value:b.ZlHaU}))); 
+    zlClU.setData(series.map(b=>({time:b.time, value:b.ZlClU}))); 
+    zlHaD.setData(series.map(b=>({time:b.time, value:b.ZlHaD}))); 
+    zlClD.setData(series.map(b=>({time:b.time, value:b.ZlClD}))); 
 
     if(haToggle){
-        const haSeries = chart.addCandlestickSeries({upColor:'#999', downColor:'#555'});
-        haSeries.setData(series.map(b=>({time:b.time, open:b.haOpen, high:Math.max(b.h,b.haOpen), low:Math.min(b.l,b.haOpen), close:b.haC})));
+        const haSeries = chart.addCandlestickSeries({upColor:'#999', downColor:'#555'}); 
+        haSeries.setData(series.map(b=>({time:b.time, open:b.haOpen, high:Math.max(b.h,b.haOpen), low:Math.min(b.l,b.haOpen), close:b.haC}))); 
     }
 
     const signalSeries = signalChart.addHistogramSeries({


### PR DESCRIPTION
## Summary
- Pin Lightweight Charts CDN to v5.0.0 and log the loaded script version.
- Add CSS and container positioning for HACO overlay arrows.
- Render large HTML arrows on HACO chart with throttled redraw.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e426dd41083269175062c289b9923