### PR TITLE
Remove HACO overlay arrows

### DIFF
--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -5,14 +5,8 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';">
     <title>Signals - MacMarket</title>
     <link rel="stylesheet" href="style.css">
-<script type="module" src="theme.js"></script>
+    <script type="module" src="theme.js"></script>
     <script src="ticker.js"></script>
-    <style>
-        .haco-overlay { position:absolute; left:0; top:0; width:100%; height:100%; pointer-events:none; }
-        .haco-arrow { position:absolute; transform:translate(-50%,-50%); line-height:1; text-shadow:0 0 3px rgba(0,0,0,.45); font-weight:700; }
-        .haco-arrow.up   { color:#16a34a; }
-        .haco-arrow.down { color:#dc2626; }
-    </style>
 </head>
 <body>
 <div id="sidebar">

--- a/static/js/haco-ui.js
+++ b/static/js/haco-ui.js
@@ -20,38 +20,6 @@ function renderChart(series){
     const chartEl = document.getElementById('haco-chart');
     chartEl.innerHTML = '';
     const chart = LightweightCharts.createChart(chartEl, {height:400, width: chartEl.clientWidth});
-    const overlay = document.createElement('div');
-    overlay.className = 'haco-overlay';
-    chartEl.appendChild(overlay);
-
-    function drawOverlayArrows(series, chart, candleSeries, overlayEl, px = 26) {
-        overlayEl.innerHTML = '';
-        const ts = chart.timeScale();
-        for (const b of series) {
-            if (!b.upw && !b.dnw) continue;
-
-            const x = ts.timeToCoordinate(b.time);
-            const yAnchor = b.upw ? b.low ?? b.l : b.high ?? b.h;
-            const y = candleSeries.priceToCoordinate(yAnchor);
-            if (x == null || y == null) continue;
-
-            const el = document.createElement('div');
-            el.className = `haco-arrow ${b.upw ? 'up' : 'down'}`;
-            el.textContent = b.upw ? '▲' : '▼';
-            el.style.left = `${x}px`;
-            el.style.top  = `${y + (b.upw ? 14 : -14)}px`;
-            el.style.fontSize = `${px}px`;
-            overlayEl.appendChild(el);
-        }
-    }
-
-    function rafRedraw(fn) {
-        let rafId = null;
-        return function(...args){
-            if (rafId) cancelAnimationFrame(rafId);
-            rafId = requestAnimationFrame(() => fn(...args));
-        };
-    }
 
     const signalChartEl = document.getElementById('haco-signal-chart');
     if(signalChartEl){
@@ -81,13 +49,6 @@ function renderChart(series){
     });
     candleSeries.setData(candles);
     candleSeries.setMarkers(markers);
-
-    const redraw = rafRedraw(() => drawOverlayArrows(series, chart, candleSeries, overlay, 28));
-    redraw();
-
-    chart.timeScale().subscribeVisibleTimeRangeChange(redraw);
-    chart.subscribeCrosshairMove(redraw);
-    window.addEventListener('resize', redraw);
 
     const zlHaU = chart.addLineSeries({color:'blue'});
     const zlClU = chart.addLineSeries({color:'orange'});


### PR DESCRIPTION
## Summary
- remove arrow overlay styles from `signals.html`
- drop HTML overlay rendering in HACO chart and rely on built-in markers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4bec97788326b1c92b8cad1facff