### PR TITLE
fix: add non-interactive HACO overlay and arrow helper

### DIFF
--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -221,7 +221,7 @@ document.getElementById('single-symbol').addEventListener('input', e => { e.targ
       console.log('[HACO] LW Charts version (from URL):', (lw?.src.match(/@([\d.]+)/)||[])[1] || 'unknown');
     })();
   </script>
-<script src="/static/js/haco-ui.js?v=1"></script>
+<script src="/static/js/haco-ui.js?v=2"></script>
 <script src="/static/js/haco-scan.js"></script>
 <script src="help.js"></script>
 <script>initHelp("signals");</script>

--- a/static/js/haco-ui.js
+++ b/static/js/haco-ui.js
@@ -1,3 +1,83 @@
+(function(){
+  // ===== HACO big-arrow overlay helper =====
+  // Usage after your series.setData(bars):
+  //   HACOOverlay.attach({
+  //     container: document.getElementById('haco-chart'),
+  //     chart,
+  //     series: priceSeries,
+  //     bars
+  //   });
+  //
+  // `bars` should be an array of { time, open, high, low, close, upw?, dnw? }
+  // If you use different flags, map them before calling attach().
+  const HACOOverlay = (function(){
+    function ensureOverlay(container){
+      let el = container.querySelector('.haco-overlay');
+      if (!el) {
+        el = document.createElement('div');
+        el.className = 'haco-overlay';
+        // Important: appendChild (do NOT assign innerHTML on container)
+        container.appendChild(el);
+      }
+      // Enforce safety styles even if global CSS changes
+      el.style.background = 'transparent';
+      el.style.pointerEvents = 'none';
+      return el;
+    }
+
+    function computeMarkersFromBars(bars){
+      const out = [];
+      for (const b of (bars || [])) {
+        if (b?.upw)  out.push({ time: b.time, price: b.low  ?? b.close, dir: 'up'   });
+        if (b?.dnw)  out.push({ time: b.time, price: b.high ?? b.close, dir: 'down' });
+      }
+      return out;
+    }
+
+    function placeArrow({chart, series, overlay, m}){
+      const x = chart.timeScale().timeToCoordinate(m.time);
+      const y = series.priceToCoordinate(m.price);
+      if (x == null || y == null) return;
+      const el = document.createElement('div');
+      el.className = `haco-arrow ${m.dir}`;
+      el.textContent = m.dir === 'up' ? '▲' : '▼';
+      el.style.transform = `translate(${x}px, ${y}px)`;
+      overlay.appendChild(el);
+    }
+
+    function attach({container, chart, series, bars, markers}){
+      if (!container || !chart || !series) return;
+      const overlay = ensureOverlay(container);
+      let data = Array.isArray(markers) ? markers : computeMarkersFromBars(bars);
+      if (!Array.isArray(data)) data = [];
+
+      const redraw = () => {
+        overlay.innerHTML = ''; // safe: overlay-only
+        for (const m of data) placeArrow({chart, series, overlay, m});
+      };
+
+      // Keep aligned on pan/zoom and resize
+      const ro = new ResizeObserver(() => requestAnimationFrame(redraw));
+      ro.observe(container);
+      chart.timeScale().subscribeVisibleTimeRangeChange(() => requestAnimationFrame(redraw));
+      // Fallback: also redraw on a small delay if initial coordinates are null
+      setTimeout(redraw, 0);
+      setTimeout(redraw, 50);
+
+      // expose a tiny API for external updates (optional)
+      return {
+        updateMarkers(next) { data = Array.isArray(next) ? next : data; redraw(); },
+        redraw
+      };
+    }
+
+    return { attach };
+  })();
+
+  // Make available to existing HACO code
+  window.HACOOverlay = HACOOverlay;
+})();
+
 async function fetchHaco(){
     const symbol = document.getElementById('haco-symbol').value.trim();
     const timeframe = document.getElementById('haco-timeframe').value.trim();
@@ -18,12 +98,12 @@ async function fetchHaco(){
 
 function renderChart(series){
     const chartEl = document.getElementById('haco-chart');
-    chartEl.innerHTML = '';
+    chartEl.textContent = '';
     const chart = LightweightCharts.createChart(chartEl, {height:400, width: chartEl.clientWidth});
 
     const signalChartEl = document.getElementById('haco-signal-chart');
     if(signalChartEl){
-        signalChartEl.innerHTML = '';
+        signalChartEl.textContent = '';
     }
     const signalChart = LightweightCharts.createChart(signalChartEl, {
         height:100,
@@ -49,6 +129,7 @@ function renderChart(series){
     });
     candleSeries.setData(candles);
     candleSeries.setMarkers(markers);
+    HACOOverlay.attach({ container: chartEl, chart, series: candleSeries, bars: series });
 
     const zlHaU = chart.addLineSeries({color:'blue'});
     const zlClU = chart.addLineSeries({color:'orange'});

--- a/static/style.css
+++ b/static/style.css
@@ -316,3 +316,22 @@ th { border-bottom: 1px solid #ccc; }
 .metric .help { margin-left:4px; cursor:help; opacity:0.7; }
 .metric-icon{margin-right:6px;}
 
+/* ===== HACO Overlay (transparent & non-interactive) ===== */
+#haco-chart { position: relative; }
+.haco-overlay {
+  position: absolute;
+  inset: 0;
+  background: transparent !important;
+  pointer-events: none;
+  z-index: 2;
+}
+.haco-arrow {
+  position: absolute;
+  font-size: 28px;
+  line-height: 1;
+  transform: translate(-50%, -50%);
+  will-change: transform;
+}
+.haco-arrow.up   { color: green; }
+.haco-arrow.down { color: red;   }
+


### PR DESCRIPTION
## Summary
- add transparent, non-interactive overlay and arrow styles for HACO chart
- provide HACOOverlay helper to draw large arrows and keep them synced on pan/zoom/resize
- bump haco-ui.js cache-busting query param

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e752e8c4483269447dfda0274e091