### PR TITLE
Remove HACO overlay arrows and sync charts

### DIFF
--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -222,7 +222,7 @@ document.getElementById('single-symbol').addEventListener('input', e => { e.targ
       console.log('[HACO] LW Charts version (from URL):', (lw?.src.match(/@([\d.]+)/)||[])[1] || 'unknown');
     })();
   </script>
-<script src="/static/js/haco-ui.js?v=8"></script>
+<script src="/static/js/haco-ui.js?v=9"></script>
 <script src="/static/js/haco-scan.js"></script>
 <script src="help.js"></script>
 <script>initHelp("signals");</script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,3 +1,5 @@
+/* Disable HACO HTML overlay arrows entirely */
+.haco-overlay, .haco-arrow { display: none !important; }
 :root {
   --bg-color: #fafafa;
   --text-color: #333;

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,5 @@
+/* Disable HACO HTML overlay arrows entirely */
+.haco-overlay, .haco-arrow { display: none !important; }
 :root {
   --bg-color: #fafafa;
   --text-color: #333;


### PR DESCRIPTION
## Summary
- Hide legacy HACO overlay arrow elements via CSS
- Remove HTML overlay use from HACO UI and add bidirectional pan/zoom syncing between main and signal charts
- Cache-bust HACO UI script include

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e8fc0a8f88326a374cfefb10fc35b