### PR TITLE
Add moving average chart and expand political trade table

### DIFF
--- a/app.py
+++ b/app.py
@@ -288,7 +288,7 @@ async def political():
 
     if isinstance(quiver_resp, httpx.Response) and quiver_resp.status_code == 200:
         try:
-            data["quiver"] = quiver_resp.json()[:5]
+            data["quiver"] = quiver_resp.json()[:40]
         except Exception:
             pass
     if isinstance(whales_resp, httpx.Response) and whales_resp.status_code == 200:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -182,17 +182,29 @@ async function loadPolitical(){
     const renderQuiver = (arr) => {
         const section = document.createElement('div');
         section.innerHTML = '<h3>Quiver Quantitative</h3>';
-        const table = document.createElement('table');
-        table.innerHTML = `<thead><tr><th>Date</th><th>Ticker</th><th>Transaction</th><th>Range</th><th>Representative</th></tr></thead>`;
-        const tbody = document.createElement('tbody');
-        arr.forEach(i => {
-            const tr = document.createElement('tr');
-            const date = i.TransactionDate ? new Date(i.TransactionDate).toLocaleDateString() : '';
-            tr.innerHTML = `<td>${date}</td><td>${i.Ticker || i.ticker || ''}</td><td>${i.Transaction || ''}</td><td>${i.Range || ''}</td><td>${i.Representative || ''}</td>`;
-            tbody.appendChild(tr);
-        });
-        table.appendChild(tbody);
-        section.appendChild(table);
+        const wrap = document.createElement('div');
+        wrap.style.display = 'flex';
+        wrap.style.gap = '1rem';
+
+        const buildTable = (rows) => {
+            const table = document.createElement('table');
+            table.innerHTML = `<thead><tr><th>Date</th><th>Ticker</th><th>Transaction</th><th>Range</th><th>Representative</th></tr></thead>`;
+            const tbody = document.createElement('tbody');
+            rows.forEach(i => {
+                const tr = document.createElement('tr');
+                const date = i.TransactionDate ? new Date(i.TransactionDate).toLocaleDateString() : '';
+                tr.innerHTML = `<td>${date}</td><td>${i.Ticker || i.ticker || ''}</td><td>${i.Transaction || ''}</td><td>${i.Range || ''}</td><td>${i.Representative || ''}</td>`;
+                tbody.appendChild(tr);
+            });
+            table.appendChild(tbody);
+            return table;
+        };
+
+        const left = buildTable(arr.slice(0,20));
+        const right = buildTable(arr.slice(20,40));
+        wrap.appendChild(left);
+        wrap.appendChild(right);
+        section.appendChild(wrap);
         container.appendChild(section);
     };
 

--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -54,6 +54,7 @@
             <h4>Technical Signal</h4>
             <div id="tech-output"></div>
             <small>Based on 20/50 day moving average crossover.</small>
+            <div id="tech-chart" style="height:300px;margin-top:1rem;"></div>
           </div>
         </div>
         <!-- Moved here: single-symbol recommendation table (driven by #symbol) -->
@@ -138,6 +139,52 @@ function setStatus(message) {
 }
 if(localStorage.getItem('isAdmin') === '1'){ document.getElementById('admin-link').style.display='block'; }
 
+function sma(values, period){
+    const res = [];
+    let sum = 0;
+    for(let i=0;i<values.length;i++){
+        sum += values[i];
+        if(i >= period) sum -= values[i-period];
+        res.push(i >= period-1 ? sum/period : null);
+    }
+    return res;
+}
+
+function findLastCross(shortArr, longArr){
+    for(let i=shortArr.length-1;i>0;i--){
+        if(shortArr[i]==null || longArr[i]==null || shortArr[i-1]==null || longArr[i-1]==null) continue;
+        if(shortArr[i-1] < longArr[i-1] && shortArr[i] > longArr[i]) return {index:i, dir:'up'};
+        if(shortArr[i-1] > longArr[i-1] && shortArr[i] < longArr[i]) return {index:i, dir:'down'};
+    }
+    return null;
+}
+
+async function renderTechChart(sym){
+    try{
+        const res = await fetch(`/api/history?symbol=${sym}&period=6mo&interval=1d`);
+        if(!res.ok) return;
+        const hist = await res.json();
+        const dates = hist.dates;
+        const closes = hist.close;
+        const ma20 = sma(closes,20);
+        const ma50 = sma(closes,50);
+        const chartEl = document.getElementById('tech-chart');
+        chartEl.innerHTML = '';
+        const chart = LightweightCharts.createChart(chartEl,{height:300});
+        const priceSeries = chart.addLineSeries({color:'#4c78ff'});
+        const ma20Series = chart.addLineSeries({color:'green'});
+        const ma50Series = chart.addLineSeries({color:'red'});
+        const priceData = dates.map((d,i)=>({time:d,value:closes[i]}));
+        priceSeries.setData(priceData);
+        ma20Series.setData(dates.map((d,i)=>ma20[i]?{time:d,value:ma20[i]}:null).filter(Boolean));
+        ma50Series.setData(dates.map((d,i)=>ma50[i]?{time:d,value:ma50[i]}:null).filter(Boolean));
+        const cross = findLastCross(ma20,ma50);
+        if(cross){
+            priceSeries.setMarkers([{time:dates[cross.index], position: cross.dir==='up'? 'belowBar':'aboveBar', color: cross.dir==='up'? 'green':'red', shape: cross.dir==='up'? 'arrowUp':'arrowDown', text:'20/50'}]);
+        }
+    }catch(e){console.error(e);}
+}
+
 async function fetchSignal(){
     const sym = document.getElementById('symbol').value.trim().toUpperCase();
     if(!sym) return;
@@ -166,6 +213,7 @@ async function fetchSignal(){
         techEl.classList.add('bearish');
         techEl.textContent += ' \u2198';
     }
+    renderTechChart(sym);
 }
 
 async function fetchMacro(){


### PR DESCRIPTION
## Summary
- show 20/50-day moving average crossover chart with crossover marker on signals page
- extend political trading table to 40 entries split into two columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21f9cbc388326b82b973f69e0836e