### PR TITLE
feat: add HACO signals API

### DIFF
--- a/api/haco.py
+++ b/api/haco.py
@@ -1,63 +1,209 @@
-from fastapi import APIRouter, HTTPException, Query, Body
-from pydantic import BaseModel
-from typing import Optional
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Optional
 import time
+import math
+import pandas as pd
+import yfinance as yf
+
 
 router = APIRouter(prefix="/api/signals/haco", tags=["haco"])
 
 
-class ScanReq(BaseModel):
-    symbol: str
+def _parse_timeframe(tf: str) -> tuple[str, str]:
+    """Return (interval, period) for yfinance."""
+    s = (tf or "day").strip().lower()
+    if s in {"h", "1h", "hour"}:
+        return "1h", "730d"  # yfinance limit for 1h
+    if s in {"w", "1w", "1wk", "week"}:
+        return "1wk", "10y"
+    if s in {"m", "1m", "1mo", "month"}:
+        return "1mo", "max"
+    # default day
+    return "1d", "3y"
 
 
-def _resolve_symbol(
-    symbol: Optional[str] = Query(None, alias="symbol"),
-    ticker: Optional[str] = Query(None, alias="ticker"),
-    body: Optional[ScanReq] = Body(None),
+def _heikin_ashi(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute basic Heikin-Ashi columns and a simple state."""
+    ha = pd.DataFrame(index=df.index)
+    ha["close"] = (df["Open"] + df["High"] + df["Low"] + df["Close"]) / 4.0
+    ha["open"] = (df["Open"] + df["Close"]) / 2.0
+    # iterative HA open
+    for i in range(1, len(ha)):
+        ha.iloc[i, ha.columns.get_loc("open")] = (
+            ha["open"].iloc[i - 1] + ha["close"].iloc[i - 1]
+        ) / 2.0
+    ha["high"] = pd.concat([df["High"], ha["open"], ha["close"]], axis=1).max(axis=1)
+    ha["low"] = pd.concat([df["Low"], ha["open"], ha["close"]], axis=1).min(axis=1)
+    ha["upbar"] = (ha["close"] > ha["open"]).astype(int)
+    return ha
+
+
+def _consecutive(arr: pd.Series) -> pd.Series:
+    """Length of current consecutive True (1) run at each index."""
+    out = []
+    run = 0
+    for v in arr.astype(bool).tolist():
+        run = run + 1 if v else 0
+        out.append(run)
+    return pd.Series(out, index=arr.index)
+
+
+def _build_series(
+    symbol: str,
+    timeframe: str,
+    len_up: int,
+    len_dn: int,
+    lookback: int,
+    show_ha: bool,
 ):
-    """Accept symbol from body or either query param name."""
-    s = (body.symbol if body else None) or symbol or ticker
-    if not s or not s.strip():
-        # 400 (not 422) so frontend handles cleanly
-        raise HTTPException(status_code=400, detail="symbol_required")
-    return s.strip().upper()
+    interval, period = _parse_timeframe(timeframe)
+    try:
+        df = yf.download(
+            symbol, period=period, interval=interval, auto_adjust=False, progress=False
+        )
+    except Exception as e:  # pragma: no cover - network
+        raise HTTPException(status_code=502, detail=f"download_failed: {e}")
+    if df is None or df.empty:
+        raise HTTPException(status_code=404, detail="no_data")
+
+    df = df.dropna().tail(max(lookback, 200))
+    ha = _heikin_ashi(df)
+    up_run = _consecutive(ha["upbar"])
+    dn_run = _consecutive(1 - ha["upbar"])
+
+    # Up/Down warnings: raised when a consecutive-run hits threshold on this bar
+    upw = (up_run >= max(1, len_up)) & (
+        up_run.shift(1, fill_value=0) < max(1, len_up)
+    )
+    dnw = (dn_run >= max(1, len_dn)) & (
+        dn_run.shift(1, fill_value=0) < max(1, len_dn)
+    )
+
+    # Optional "ZL" lines (very lightweight proxies)
+    zl_ha_u = ha["close"].where(ha["upbar"] == 1)
+    zl_cl_u = df["Close"].where(ha["upbar"] == 1)
+    zl_ha_d = ha["close"].where(ha["upbar"] == 0)
+    zl_cl_d = df["Close"].where(ha["upbar"] == 0)
+
+    out: List[dict] = []
+    for ts, row in df.iterrows():
+        sec = int(ts.to_pydatetime().timestamp())
+        i = df.index.get_loc(ts)
+        # choose price source based on HA toggle (UI asks "Show Heikin-Ashi")
+        if show_ha:
+            o, h, l, c = (
+                float(ha["open"].iloc[i]),
+                float(ha["high"].iloc[i]),
+                float(ha["low"].iloc[i]),
+                float(ha["close"].iloc[i]),
+            )
+        else:
+            o, h, l, c = (
+                float(row["Open"]),
+                float(row["High"]),
+                float(row["Low"]),
+                float(row["Close"]),
+            )
+        out.append(
+            {
+                "time": sec,
+                "o": o,
+                "h": h,
+                "l": l,
+                "c": c,
+                "state": bool(ha["upbar"].iloc[i]),
+                "upw": bool(upw.iloc[i]),
+                "dnw": bool(dnw.iloc[i]),
+                "ZlHaU": float(zl_ha_u.iloc[i])
+                if not math.isnan(zl_ha_u.iloc[i])
+                else None,
+                "ZlClU": float(zl_cl_u.iloc[i])
+                if not math.isnan(zl_cl_u.iloc[i])
+                else None,
+                "ZlHaD": float(zl_ha_d.iloc[i])
+                if not math.isnan(zl_ha_d.iloc[i])
+                else None,
+                "ZlClD": float(zl_cl_d.iloc[i])
+                if not math.isnan(zl_cl_d.iloc[i])
+                else None,
+            }
+        )
+
+    last = out[-1]
+    # crude "reasons" string; good enough for UI
+    reasons: List[str] = []
+    reasons.append("HA up" if last["state"] else "HA down")
+    if last["upw"]:
+        reasons.append(f"run≥{len_up}")
+    if last["dnw"]:
+        reasons.append(f"run≥{len_dn}")
+    return {
+        "series": out,
+        "last": {
+            "state": last["state"],
+            "upw": last["upw"],
+            "dnw": last["dnw"],
+            "reasons": ", ".join(reasons),
+        },
+    }
 
 
-def _stub_payload(sym: str):
-    now = int(time.time())
-    candles = []
-    # 50 hourly bars, gently moving so chart is visibly alive
-    base = 100.0
-    for i in range(50):
-        t = now - (50 - i) * 3600
-        o = base + i * 0.2
-        c = o + (0.5 if i % 2 else -0.3)
-        h = max(o, c) + 0.6
-        l = min(o, c) - 0.6
-        candles.append({"time": t, "open": o, "high": h, "low": l, "close": c})
-    markers = [
-        {
-            "time": candles[-1]["time"],
-            "position": "belowBar",
-            "shape": "arrowUp",
-            "color": "green",
-            "text": f"HACO {sym}",
-        }
-    ]
-    return {"candles": candles, "markers": markers}
-
-
-@router.post("/scan")
-async def scan_post(payload: ScanReq = Body(...)):
-    sym = _resolve_symbol(body=payload)
-    return _stub_payload(sym)
+@router.get("")
+def haco(
+    symbol: str = Query(..., alias="symbol"),
+    timeframe: str = Query("Day"),
+    lengthUp: int = Query(34, ge=1),
+    lengthDown: int = Query(34, ge=1),
+    alertLookback: int = Query(1, ge=1),
+    lookback: int = Query(200, ge=50),
+    showHa: Optional[bool] = Query(False, alias="showHa"),
+):
+    """Return HACO bars for a single symbol."""
+    return _build_series(
+        symbol.strip().upper(),
+        timeframe,
+        lengthUp,
+        lengthDown,
+        lookback,
+        bool(showHa),
+    )
 
 
 @router.get("/scan")
-async def scan_get(
-    symbol: Optional[str] = Query(None, alias="symbol"),
-    ticker: Optional[str] = Query(None, alias="ticker"),
+def haco_scan(
+    symbols: str = Query(..., description="Comma separated symbols"),
+    timeframe: str = Query("Day"),
 ):
-    sym = _resolve_symbol(symbol=symbol, ticker=ticker)
-    return _stub_payload(sym)
+    """Return last-bar HACO flags for many symbols (for the HACO table)."""
+    syms = [s.strip().upper() for s in symbols.split(",") if s.strip()]
+    if not syms:
+        return []
+    out = []
+    for s in syms:
+        try:
+            data = _build_series(s, timeframe, 34, 34, 200, False)
+            ser = data["series"]
+            if not ser:
+                out.append({"symbol": s, "error": "no_data"})
+                continue
+            last = ser[-1]
+            prev = ser[-2] if len(ser) > 1 else None
+            changed = (prev is not None) and (
+                bool(prev.get("state")) != bool(last.get("state"))
+            )
+            out.append(
+                {
+                    "symbol": s,
+                    "upw": last.get("upw", False),
+                    "dnw": last.get("dnw", False),
+                    "state": last.get("state", None),
+                    "changed": changed,
+                    "reason": data["last"].get("reasons", ""),
+                }
+            )
+        except HTTPException as ex:  # pragma: no cover - network errors
+            out.append({"symbol": s, "error": ex.detail})
+        except Exception as e:  # pragma: no cover - defensive
+            out.append({"symbol": s, "error": str(e)})
+    return out
 

--- a/tests/test_haco_api.py
+++ b/tests/test_haco_api.py
@@ -1,0 +1,77 @@
+from fastapi.testclient import TestClient
+
+from app import app
+import api.haco as haco
+
+
+client = TestClient(app)
+
+
+def test_haco_endpoint(monkeypatch):
+    def fake_build(symbol, timeframe, len_up, len_dn, lookback, show_ha):
+        assert symbol == "AAPL"
+        assert timeframe == "Day"
+        assert len_up == 3
+        assert len_dn == 4
+        assert lookback == 200
+        assert show_ha is True
+        return {
+            "series": [
+                {
+                    "time": 1,
+                    "o": 1,
+                    "h": 1,
+                    "l": 1,
+                    "c": 1,
+                    "state": True,
+                    "upw": False,
+                    "dnw": False,
+                    "ZlHaU": None,
+                    "ZlClU": None,
+                    "ZlHaD": None,
+                    "ZlClD": None,
+                }
+            ],
+            "last": {"state": True, "upw": False, "dnw": False, "reasons": "HA up"},
+        }
+
+    monkeypatch.setattr(haco, "_build_series", fake_build)
+
+    resp = client.get(
+        "/api/signals/haco?symbol=AAPL&timeframe=Day&lengthUp=3&lengthDown=4&lookback=200&showHa=true"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "series" in data and "last" in data
+    assert data["series"][0]["time"] == 1
+
+
+def test_haco_scan(monkeypatch):
+    def fake_build(symbol, timeframe, len_up, len_dn, lookback, show_ha):
+        if symbol == "AAPL":
+            series = [
+                {"state": False, "upw": False, "dnw": False},
+                {"state": True, "upw": True, "dnw": False},
+            ]
+            last = {"state": True, "upw": True, "dnw": False, "reasons": "HA up"}
+        else:
+            series = [
+                {"state": True, "upw": False, "dnw": False},
+                {"state": True, "upw": False, "dnw": False},
+            ]
+            last = {"state": True, "upw": False, "dnw": False, "reasons": "HA up"}
+        return {"series": series, "last": last}
+
+    monkeypatch.setattr(haco, "_build_series", fake_build)
+
+    resp = client.get("/api/signals/haco/scan?symbols=AAPL,MSFT")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    aapl = next(item for item in data if item["symbol"] == "AAPL")
+    msft = next(item for item in data if item["symbol"] == "MSFT")
+    assert aapl["changed"] is True
+    assert msft["changed"] is False
+    assert aapl["upw"] is True
+    assert msft["upw"] is False
+


### PR DESCRIPTION
## Summary
- expose `/api/signals/haco` to deliver HACO series and state info
- add `/api/signals/haco/scan` for bulk last-bar HACO flags
- cover new endpoints with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d839351c8326b0eee35dd82dee38