### PR TITLE
Fix HACO candle rendering and markers

### DIFF
--- a/frontend/signals.html
+++ b/frontend/signals.html
@@ -42,7 +42,7 @@
       <section class="signal-section symbol-signal">
         <h3>Symbol Signal</h3>
         <form id="symbol-form" class="row-controls" onsubmit="return false">
-          <label>Symbol <input id="symbol" type="text" value="SPY" autocomplete="off"></label>
+          <label>Symbol <input id="symbol" type="text" value="SPY"></label>
           <button id="get-signal" type="submit" aria-label="Run HACO">Run</button>
         </form>
         <div id="signal-container">


### PR DESCRIPTION
## Summary
- render price candles on the right scale while HACO lines use a hidden left scale
- restore arrow markers and support showHa toggle in HACO API requests
- default the signal and HACO symbol inputs to SPY

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: jinja2 must be installed to use Jinja2Templates)*

------
https://chatgpt.com/codex/tasks/task_e_68a45b5de52c8326aa296a78ba2cf099