### PR TITLE
feat: add per-alert CRUD and worker

### DIFF
--- a/static/js/alerts.js
+++ b/static/js/alerts.js
@@ -1,0 +1,99 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $ = (s)=>document.querySelector(s);
+  const statusEl = $('#alert-status');
+  const tableBody = $('#alerts-table tbody');
+
+  async function load() {
+    status('Loading…');
+    const r = await fetch('/api/alerts?userId=1');
+    const rows = r.ok ? await r.json() : [];
+    tableBody.innerHTML = '';
+    for (const a of rows) {
+      tableBody.appendChild(rowEl(a));
+    }
+    status(`Loaded ${rows.length} alerts`);
+  }
+
+  function rowEl(a){
+    const tr = document.createElement('tr');
+    tr.dataset.id = a.id;
+    tr.innerHTML = `
+      <td><input value="${a.symbol}" class="inp-symbol"></td>
+      <td>
+        <select class="inp-strategy">
+          <option ${a.strategy==='HACO'?'selected':''}>HACO</option>
+          <option ${a.strategy==='MACD'?'selected':''}>MACD</option>
+        </select>
+      </td>
+      <td>
+        <select class="inp-freq">
+          ${['5m','15m','1h','1d'].map(f=>`<option ${a.frequency===f?'selected':''}>${f}</option>`).join('')}
+        </select>
+      </td>
+      <td><input value="${a.email||''}" class="inp-email"></td>
+      <td><input value="${a.sms||''}" class="inp-sms"></td>
+      <td style="text-align:center;"><input type="checkbox" class="inp-enabled" ${a.is_enabled? 'checked':''}></td>
+      <td>
+        <button class="btn-save">Save</button>
+        <button class="btn-tpl">Templates</button>
+        <button class="btn-del">Delete</button>
+      </td>`;
+    tr.querySelector('.btn-save').addEventListener('click', ()=> save(tr));
+    tr.querySelector('.btn-del').addEventListener('click', ()=> del(tr));
+    tr.querySelector('.btn-tpl').addEventListener('click', ()=> editTpl(tr, a));
+    return tr;
+  }
+
+  function status(msg){ if(statusEl) statusEl.textContent = msg; }
+
+  async function save(tr){
+    const id = tr.dataset.id;
+    const payload = {
+      symbol: tr.querySelector('.inp-symbol').value.trim().toUpperCase(),
+      strategy: tr.querySelector('.inp-strategy').value,
+      frequency: tr.querySelector('.inp-freq').value,
+      email: tr.querySelector('.inp-email').value.trim() || null,
+      sms: tr.querySelector('.inp-sms').value.trim() || null,
+      is_enabled: tr.querySelector('.inp-enabled').checked ? 1 : 0
+    };
+    const r = await fetch(`/api/alerts/${id}`, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
+    status(r.ok ? 'Saved' : 'Save failed');
+  }
+
+  async function del(tr){
+    const id = tr.dataset.id;
+    if(!confirm('Delete this alert?')) return;
+    const r = await fetch(`/api/alerts/${id}`, {method:'DELETE'});
+    if(r.ok){ tr.remove(); status('Deleted'); } else { status('Delete failed'); }
+  }
+
+  async function create(){
+    const payload = {
+      user_id: Number(document.getElementById('a-user').value||1),
+      symbol: document.getElementById('a-symbol').value.trim().toUpperCase(),
+      strategy: document.getElementById('a-strategy').value,
+      frequency: document.getElementById('a-freq').value,
+      email: document.getElementById('a-email').value.trim() || null,
+      sms: document.getElementById('a-sms').value.trim() || null,
+      is_enabled: 1
+    };
+    const r = await fetch('/api/alerts', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
+    if(r.ok){ await load(); status('Created'); } else { status('Create failed'); }
+  }
+
+  async function editTpl(tr, a0){
+    const id = tr.dataset.id;
+    // lightweight “modal”: prompt for email & sms template
+    const curEmail = a0.email_template || 'HACO {{symbol}} changed to {{state}} on {{ts}} ({{frequency}}). Reason: {{reason}}';
+    const curSms   = a0.sms_template   || '{{symbol}} {{state}} ({{strategy}} {{frequency}}).';
+    const email_template = prompt('Email template (use {{symbol}} {{strategy}} {{frequency}} {{state}} {{reason}} {{ts}} {{price}}):', curEmail);
+    if(email_template===null) return;
+    const sms_template = prompt('SMS template:', curSms);
+    if(sms_template===null) return;
+    const r = await fetch(`/api/alerts/${id}`, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify({email_template, sms_template})});
+    status(r.ok ? 'Templates saved' : 'Save failed');
+  }
+
+  document.getElementById('a-create')?.addEventListener('click', create);
+  load();
+});

--- a/templates/alerts.html
+++ b/templates/alerts.html
@@ -1,54 +1,33 @@
 {% extends "base.html" %}
 {% block title %}Alerts{% endblock %}
 {% block content %}
-<div class="container">
-  <h1>Trading Alerts</h1>
-  <p>Select which strategy to monitor. The system will run your chosen strategy at the frequency you set. If the signal flips (long→short or short→long), you’ll get an alert.</p>
+  <h2>Alerts</h2>
+  <!-- Per-alert manager -->
+  <section class="card" style="padding:.5rem;">
+    <h3>Manage Alerts</h3>
+    <form id="alert-new" class="row" onsubmit="return false" style="display:flex;gap:.5rem;flex-wrap:wrap;align-items:end;">
+      <label>User ID <input id="a-user" type="number" value="1"></label>
+      <label>Symbol <input id="a-symbol" value="SPY"></label>
+      <label>Strategy
+        <select id="a-strategy"><option>HACO</option><option>MACD</option></select>
+      </label>
+      <label>Frequency
+        <select id="a-freq"><option>5m</option><option>15m</option><option selected>1h</option><option>1d</option></select>
+      </label>
+      <label>Email <input id="a-email" placeholder="me@example.com"></label>
+      <label>SMS <input id="a-sms" placeholder="+15551234567"></label>
+      <button id="a-create" type="button">Add Alert</button>
+    </form>
 
-  <section class="card">
-    <h2>Strategy</h2>
-    <select id="alert-strategy">
-      <option value="HACO">HACO (High-Accuracy Composite Oscillator)</option>
-      <option value="SMA">SMA Crossover</option>
-      <option value="MACD">MACD</option>
-    </select>
-    <small>This determines how the signal is calculated.</small>
+    <div id="alert-status" class="muted" aria-live="polite" style="margin:.5rem 0;"></div>
+
+    <table id="alerts-table" class="table">
+      <thead><tr>
+        <th>Symbol</th><th>Strategy</th><th>Freq</th><th>Email</th><th>SMS</th><th>Enabled</th><th>Actions</th>
+      </tr></thead>
+      <tbody></tbody>
+    </table>
   </section>
-
-  <section class="card">
-    <h2>Frequency</h2>
-    <select id="alert-frequency">
-      <option value="5m">Every 5 minutes</option>
-      <option value="15m">Every 15 minutes</option>
-      <option value="1h">Hourly</option>
-      <option value="1d">Daily</option>
-    </select>
-    <small>This is how often the server checks the strategy.</small>
-  </section>
-
-  <section class="card">
-    <h2>Delivery</h2>
-    <label>Email <input id="alert-email" type="email" placeholder="you@example.com"></label>
-    <label>SMS <input id="alert-sms" type="tel" placeholder="+13175551234"></label>
-    <small>You’ll receive alerts here when the signal changes.</small>
-  </section>
-
-  <section class="card">
-    <h2>Symbols</h2>
-    <div class="row">
-      <input id="symbol-input" type="text" placeholder="AAPL">
-      <button id="add-symbol">Add</button>
-    </div>
-    <div id="symbol-list" class="symbol-cards"></div>
-    <small>Symbols are enriched with company name and price for easy review.</small>
-  </section>
-
-  <div class="row">
-    <button id="save-alerts">Save Settings</button>
-    <button id="test-alerts" class="secondary">Run Test</button>
-  </div>
-
-  <div id="toast" class="toast" style="display:none;"></div>
-</div>
-<script src="/static/js/alerts.js"></script>
+  <script src="help.js"></script>
+  <script src="/js/alerts.js?v=1"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add alert worker that evaluates per-alert rows and sends notifications
- expose CRUD API for user alerts
- add client UI and script for managing alerts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aba6d4bc7c8326a748684cca685ee9